### PR TITLE
Improve scrolling performance

### DIFF
--- a/lib/minimap-lens.js
+++ b/lib/minimap-lens.js
@@ -122,8 +122,23 @@ class MinimapLens {
 
   showLens(editor, layerY) {
     if (!editor || this.lensMap.has(editor)) return;
-
+    const item = editor.copy();
     const minimap = this.minimap.minimapForEditor(editor);
+
+    if (!this.lensView || this.editor != editor) {
+      const itemView = this.prepareCreateLens(minimap, editor, item);
+      this.editor = editor; // used to check if editor is new
+      this.lensView = this.createLens(minimap, editor, itemView); // create lens
+    } else {
+      this.lensView.style.display = ''; // show
+    }
+    this.lensMap.set(editor, { lens: this.lensView, item });
+
+    this.setLensPosition(minimap, editor, this.lensView, layerY);
+  }
+
+  // calculations needed for createLens
+  prepareCreateLens(minimap, editor, item) {
     const minimapElement = atom.views.getView(minimap);
     const editorView = atom.views.getView(editor);
     const editorHeight = parseInt(
@@ -146,7 +161,6 @@ class MinimapLens {
       editorWidth = editorWidth - minimapElement.clientWidth;
     }
 
-    const item = editor.copy();
     const itemView = atom.views.getView(item);
     itemView.style.height = `${editorHeight}px`;
     itemView.style.width = `${editorWidth}px`;
@@ -156,16 +170,7 @@ class MinimapLens {
     pane.addItem(item);
     pane.removeItem(item);
 
-    if (!this.lensView || this.editor != editor) {
-      // create for the first time
-      this.editor = editor; // used to check if editor is new
-      this.lensView = this.createLens(minimap, editor, itemView);
-    } else {
-      this.lensView.style.display = ''; // show
-    }
-    this.lensMap.set(editor, { lens: this.lensView, item });
-
-    this.setLensPosition(minimap, editor, this.lensView, layerY);
+    return itemView;
   }
 
   createLens(minimap, editor, itemView) {

--- a/lib/minimap-lens.js
+++ b/lib/minimap-lens.js
@@ -44,7 +44,7 @@ class MinimapLens {
   }
 
   deactivate() {
-    this.destroyLens()
+    this.destroyLens();
     this.minimap.unregisterPlugin('lens-mode');
     this.minimap = null;
   }
@@ -104,7 +104,7 @@ class MinimapLens {
       clearTimeout(this.timeoutId);
       this.timeoutId = null;
     } else {
-      this.hideLens()
+      this.hideLens();
     }
   }
 
@@ -156,12 +156,12 @@ class MinimapLens {
     pane.addItem(item);
     pane.removeItem(item);
 
-    if (!this.lensView || this.editor != editor ) {
+    if (!this.lensView || this.editor != editor) {
       // create for the first time
-      this.editor = editor // used to check if editor is new
+      this.editor = editor; // used to check if editor is new
       this.lensView = this.createLens(minimap, editor, itemView);
     } else {
-      this.lensView.style.display = ""; // show
+      this.lensView.style.display = ''; // show
     }
     this.lensMap.set(editor, { lens: this.lensView, item });
 
@@ -234,21 +234,26 @@ class MinimapLens {
   }
 
   hideLens() {
-    this.lensView.style.display = "none"; // hide
+    this.lensView.style.display = 'none'; // hide
     this.lensMap.delete(this.previousEditor);
   }
 
   destroyLens() {
     // clear previous lens memory
     if (this.previousEditor && this.lensMap.has(this.previousEditor)) {
-      const { previousLens, previousItem } = this.lensMap.get(this.previousEditor);
-      if (previousItem) { previousItem.destroy(); }
-      if (previousLens) { previousLens.remove(); }
+      const { previousLens, previousItem } = this.lensMap.get(
+        this.previousEditor
+      );
+      if (previousItem) {
+        previousItem.destroy();
+      }
+      if (previousLens) {
+        previousLens.remove();
+      }
       this.lensMap.delete(this.previousEditor);
     }
     this.previousEditor = this.editor; // update previousEditor
   }
-
 }
 
 export default new MinimapLens();

--- a/lib/minimap-lens.js
+++ b/lib/minimap-lens.js
@@ -44,6 +44,7 @@ class MinimapLens {
   }
 
   deactivate() {
+    this.destroyLens()
     this.minimap.unregisterPlugin('lens-mode');
     this.minimap = null;
   }
@@ -103,7 +104,7 @@ class MinimapLens {
       clearTimeout(this.timeoutId);
       this.timeoutId = null;
     } else {
-      this.destroyLens(editor);
+      this.hideLens()
     }
   }
 
@@ -155,11 +156,20 @@ class MinimapLens {
     pane.addItem(item);
     pane.removeItem(item);
 
-    const lens = this.createLens(minimap, editor, item, itemView);
-    this.setLensPosition(minimap, editor, lens, layerY);
+    if (!this.lensView || this.editor != editor ) {
+      // create for the first time
+      this.editor = editor // used to check if editor is new
+      this.lensView = this.createLens(minimap, editor, itemView);
+    } else {
+      this.lensView.style.display = ""; // show
+    }
+    this.lensMap.set(editor, { lens: this.lensView, item });
+
+    this.setLensPosition(minimap, editor, this.lensView, layerY);
   }
 
-  createLens(minimap, editor, item, itemView) {
+  createLens(minimap, editor, itemView) {
+    this.destroyLens(); // clean last lens memory
     const lensHeight = atom.config.get('minimap-lens.lensHeight');
     const clipInner = document.createElement('div');
     clipInner.classList.add('clip-inner');
@@ -179,7 +189,6 @@ class MinimapLens {
     }
 
     const lens = atom.views.getView(editor).appendChild(lensContainer);
-    this.lensMap.set(editor, { lens, item });
 
     return lens;
   }
@@ -221,16 +230,25 @@ class MinimapLens {
   updateLensPosition(editor, layerY) {
     if (!this.lensMap.has(editor)) return;
     const minimap = this.minimap.minimapForEditor(editor);
-    const { lens } = this.lensMap.get(editor);
-    this.setLensPosition(minimap, editor, lens, layerY);
+    this.setLensPosition(minimap, editor, this.lensView, layerY);
   }
 
-  destroyLens(editor) {
-    const { lens, item } = this.lensMap.get(editor);
-    item.destroy();
-    lens.remove();
-    this.lensMap.delete(editor);
+  hideLens() {
+    this.lensView.style.display = "none"; // hide
+    this.lensMap.delete(this.previousEditor);
   }
+
+  destroyLens() {
+    // clear previous lens memory
+    if (this.previousEditor && this.lensMap.has(this.previousEditor)) {
+      const { previousLens, previousItem } = this.lensMap.get(this.previousEditor);
+      if (previousItem) { previousItem.destroy(); }
+      if (previousLens) { previousLens.remove(); }
+      this.lensMap.delete(this.previousEditor);
+    }
+    this.previousEditor = this.editor; // update previousEditor
+  }
+
 }
 
 export default new MinimapLens();


### PR DESCRIPTION
- This fixes the glitches that minimap-lens causes in the scrolling. createLense function takes 300ms to run every time! Now it only runs once.
- Cleans previous memory when someone switches to another editor.