### PR TITLE
Hide lens when mouse is pressed

### DIFF
--- a/lib/minimap-lens.js
+++ b/lib/minimap-lens.js
@@ -60,16 +60,22 @@ class MinimapLens {
       const onMouseEnter = this.onMouseEnter.bind(this, editor);
       const onMouseMove = this.onMouseMove.bind(this, editor);
       const onMouseLeave = this.onMouseLeave.bind(this, editor);
+      const onMousePressed = this.onMousePressed.bind(this, editor);
+      const onMouseReleased = this.onMouseReleased.bind(this, editor);
 
       const listeners = {
         onMouseEnter,
         onMouseMove,
-        onMouseLeave
+        onMouseLeave,
+        onMousePressed,
+        onMouseReleased
       };
 
       minimapElement.addEventListener('mouseenter', onMouseEnter);
       minimapElement.addEventListener('mousemove', onMouseMove);
       minimapElement.addEventListener('mouseleave', onMouseLeave);
+      minimapElement.addEventListener('mousedown', onMousePressed);
+      minimapElement.addEventListener('mouseup', onMouseReleased);
 
       this.listenersMap.set(minimapElement, listeners);
     });
@@ -108,6 +114,20 @@ class MinimapLens {
     }
   }
 
+  onMousePressed(editor, e) {
+    // if mouse is pressed hide the lens
+    if (typeof e === 'object' && e.button == 0) {
+      this.hideLens();
+    }
+  }
+
+  onMouseReleased(editor, e) {
+    // when mouse is released show the lens
+    if (typeof e === 'object' && e.button == 0) {
+      this.showLens(editor, e.layerY);
+    }
+  }
+
   unbindAllEvents() {
     const editors = atom.workspace.getTextEditors();
     for (let editor of editors) {
@@ -117,6 +137,8 @@ class MinimapLens {
       minimapElement.removeEventListener('mouseenter', listeners.onMouseEnter);
       minimapElement.removeEventListener('mousemove', listeners.onMouseMove);
       minimapElement.removeEventListener('mouseleave', listeners.onMouseLeave);
+      minimapElement.removeEventListener('mousedown', listeners.onMousePressed);
+      minimapElement.removeEventListener('mouseup', listeners.onMouseReleased);
     }
   }
 
@@ -239,6 +261,9 @@ class MinimapLens {
   }
 
   hideLens() {
+    if (!this.lensView) {
+      return;
+    }
     this.lensView.style.display = 'none'; // hide
     this.lensMap.delete(this.previousEditor);
   }


### PR DESCRIPTION
This hides the lens when the left click on the mouse is pressed. 

This is particularly useful when the user is scrolling by holding left-click. This prevents the lens to be shown during scrolling until the user releases the left-click.

![hide_when_pressed](https://user-images.githubusercontent.com/16418197/87260111-70beed80-c475-11ea-8097-90ac00628e12.gif)

Fixes #1