### PR TITLE
use activation hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
       }
     }
   },
+  "activationHooks": [
+    "core:loaded-shell-environment"
+  ],
   "dependencies": {},
   "devDependencies": {
     "babel-eslint": "^10.0.1",

--- a/spec/minimap-lens-spec.js
+++ b/spec/minimap-lens-spec.js
@@ -19,6 +19,10 @@ describe('MinimapLens', () => {
       })
     );
 
+    // Package activation will be deferred to the configured, activation hook, which is then triggered
+    // Activate activation hook
+    atom.packages.triggerDeferredActivationHooks();
+    atom.packages.triggerActivationHook('core:loaded-shell-environment');
     waitsForPromise(() => atom.packages.activatePackage('minimap-lens'));
 
     runs(() => {


### PR DESCRIPTION
 This speeds up loading of Atom, by deferring the loading of minimap-lens until the core Atom shell is loaded. 

This is apparent when you have an editor open from the previous session. Prior to this, minimap-lens slowed down the loading of the editor 500ms!

Later in the future pull requests, I will improve this time itself, but for now, the activation hook does the trick.