### PR TITLE
calculate and cache editor width

### DIFF
--- a/lib/minimap-lens.js
+++ b/lib/minimap-lens.js
@@ -147,9 +147,16 @@ class MinimapLens {
     const item = editor.copy();
     const minimap = this.minimap.minimapForEditor(editor);
 
-    if (!this.lensView || this.editor != editor) {
-      const itemView = this.prepareCreateLens(minimap, editor, item);
-      this.editor = editor; // used to check if editor is new
+    const [editorWidth, editorHeight] = this.calcEditorDims(minimap, editor);
+
+    if (
+      !this.lensView ||
+      this.editor != editor ||
+      this.editorWidth != editorWidth
+    ) {
+      const itemView = this.prepareCreateLens(item, editorHeight, editorWidth);
+      this.editor = editor; // update editor cache (to check if editor is new)
+      this.editorWidth = editorWidth; // update editorWidth cache (to check if width has changed)
       this.lensView = this.createLens(minimap, editor, itemView); // create lens
       if (!this.lensView) {
         return;
@@ -162,8 +169,8 @@ class MinimapLens {
     this.setLensPosition(minimap, editor, this.lensView, layerY);
   }
 
-  // calculations needed for createLens
-  prepareCreateLens(minimap, editor, item) {
+  // editor dimensions calculations needed for createLens
+  calcEditorDims(minimap, editor) {
     const minimapElement = atom.views.getView(minimap);
     const editorView = atom.views.getView(editor);
     const editorHeight = parseInt(
@@ -186,6 +193,10 @@ class MinimapLens {
       editorWidth = editorWidth - minimapElement.clientWidth;
     }
 
+    return [editorWidth, editorHeight];
+  }
+
+  prepareCreateLens(item, editorHeight, editorWidth) {
     const itemView = atom.views.getView(item);
     if (!itemView) {
       return null;


### PR DESCRIPTION
This catches the editor's width, so if the user changes the width (e.g. by opening or closing side tabs), the new width is checked against the cache, and a new lens is created if needed.

![cache_width](https://user-images.githubusercontent.com/16418197/87453414-15e9db00-c5c8-11ea-95f4-578a195ce6fd.gif)

There might be a CSS solution instead of JavaScript, but since the code was already JavaScript, I kept it for now.