### PR TITLE
Proper caching system

### DIFF
--- a/lib/minimap-lens.js
+++ b/lib/minimap-lens.js
@@ -43,7 +43,9 @@ class MinimapLens {
   editorObserver() {
     const activeTextEditorObserver = atom.workspace.observeActiveTextEditor(
       editor => {
-        editor.onDidDestroy(() => this.destroyLens(editor));
+        if (editor) {
+          editor.onDidDestroy(() => this.destroyLens(editor));
+        }
       }
     );
     this.subscriptions.add(activeTextEditorObserver);

--- a/lib/minimap-lens.js
+++ b/lib/minimap-lens.js
@@ -298,21 +298,18 @@ class MinimapLens {
     this.lensView.style.display = 'none'; // hide
   }
 
-  destroyLens() {
-    // clear previous lens memory
-    if (this.previousEditor && this.lensMap.has(this.previousEditor)) {
-      const { previousLens, previousItem } = this.lensMap.get(
-        this.previousEditor
-      );
-      if (previousItem) {
-        previousItem.destroy();
+  // clears the lens memory of the given editor if it had lens
+  destroyLens(editor) {
+    if (this.lensMap.has(editor)) {
+      const { lens, item } = this.lensMap.get(editor);
+      if (item) {
+        item.destroy();
       }
-      if (previousLens) {
-        previousLens.remove();
+      if (lens) {
+        lens.remove();
       }
-      this.lensMap.delete(this.previousEditor);
+      this.lensMap.delete(editor);
     }
-    this.previousEditor = this.editor; // update previousEditor
   }
 }
 

--- a/lib/minimap-lens.js
+++ b/lib/minimap-lens.js
@@ -36,6 +36,17 @@ class MinimapLens {
         this.timeoutDelay = v;
       })
     );
+    this.editorObserver();
+  }
+
+  // removes the lens when editor is destroyed
+  editorObserver() {
+    const activeTextEditorObserver = atom.workspace.observeActiveTextEditor(
+      editor => {
+        editor.onDidDestroy(() => this.destroyLens(editor));
+      }
+    );
+    this.subscriptions.add(activeTextEditorObserver);
   }
 
   consumeMinimapServiceV1(minimap1) {
@@ -216,7 +227,6 @@ class MinimapLens {
     if (!itemView) {
       return null;
     }
-    this.destroyLens(); // clean last lens memory
     const lensHeight = atom.config.get('minimap-lens.lensHeight');
     const clipInner = document.createElement('div');
     clipInner.classList.add('clip-inner');
@@ -280,12 +290,12 @@ class MinimapLens {
     this.setLensPosition(minimap, editor, this.lensView, layerY);
   }
 
+  // hides the lense when mouse leaves the minimap
   hideLens() {
     if (!this.lensView) {
       return;
     }
     this.lensView.style.display = 'none'; // hide
-    this.lensMap.delete(this.previousEditor);
   }
 
   destroyLens() {

--- a/lib/minimap-lens.js
+++ b/lib/minimap-lens.js
@@ -154,29 +154,30 @@ class MinimapLens {
   }
 
   showLens(editor, layerY) {
-    if (!editor || this.lensMap.has(editor)) return;
-    const item = editor.copy();
-    const minimap = this.minimap.minimapForEditor(editor);
+    if (!editor) return;
 
+    const minimap = this.minimap.minimapForEditor(editor);
     const [editorWidth, editorHeight] = this.calcEditorDims(minimap, editor);
 
-    if (
-      !this.lensView ||
-      this.editor != editor ||
-      this.editorWidth != editorWidth
-    ) {
+    // check if should create lens
+    const editorHasLens = this.lensMap.has(editor);
+    const shouldCreateLens =
+      !this.lensView || // no lens so far
+      !editorHasLens || // editor does not have lens
+      (editorHasLens && this.lensMap.get(editor).editorWidth !== editorWidth); // editor width has changed
+
+    if (shouldCreateLens) {
+      // create lens from scratch
+      const item = editor.copy(); // do not modify the original editor
       const itemView = this.prepareCreateLens(item, editorHeight, editorWidth);
-      this.editor = editor; // update editor cache (to check if editor is new)
-      this.editorWidth = editorWidth; // update editorWidth cache (to check if width has changed)
       this.lensView = this.createLens(minimap, editor, itemView); // create lens
       if (!this.lensView) {
         return;
       }
+      this.lensMap.set(editor, { lens: this.lensView, item, editorWidth }); // add to cache
     } else {
       this.lensView.style.display = ''; // show
     }
-    this.lensMap.set(editor, { lens: this.lensView, item });
-
     this.setLensPosition(minimap, editor, this.lensView, layerY);
   }
 

--- a/lib/minimap-lens.js
+++ b/lib/minimap-lens.js
@@ -21,7 +21,7 @@ class MinimapLens {
   constructor() {
     this.active = false;
     this.listenersMap = new WeakMap();
-    this.lensMap = new WeakMap();
+    this.lensMap = new WeakMap(); // a map from editor to {lens, item, editorWidth}
     this.timeoutId = null;
   }
 
@@ -176,7 +176,12 @@ class MinimapLens {
       }
       this.lensMap.set(editor, { lens: this.lensView, item, editorWidth }); // add to cache
     } else {
-      this.lensView.style.display = ''; // show
+      // show lens from cache
+      // get the lensView from cache
+      const lensMap = this.lensMap.get(editor);
+      this.lensView = lensMap.lens;
+      // show lens
+      this.lensView.style.display = '';
     }
     this.setLensPosition(minimap, editor, this.lensView, layerY);
   }


### PR DESCRIPTION
This improves the caching system: 
- destroys the lens only when the editor is destroyed
- adds to the cache only when the editor is created (if completely new or width has changed)
- The cache now tracks multiple editors instead of only the previous one (so less lens creation overall)

This optimizes `showLens` even more so unnecessary operations such as `editor.copy` do not happen every time the lens wants to be shown. 


@iyonaga 