### PR TITLE
Fast setLensPosition

### DIFF
--- a/lib/minimap-lens.js
+++ b/lib/minimap-lens.js
@@ -238,10 +238,9 @@ class MinimapLens {
     if (!itemView) {
       return null;
     }
-    const lensHeight = atom.config.get('minimap-lens.lensHeight');
     const clipInner = document.createElement('div');
     clipInner.classList.add('clip-inner');
-    clipInner.style.height = `${lensHeight}px`;
+    clipInner.style.height = `${this.lensHeight}px`;
     clipInner.appendChild(itemView);
 
     const clip = document.createElement('div');

--- a/lib/minimap-lens.js
+++ b/lib/minimap-lens.js
@@ -21,7 +21,7 @@ class MinimapLens {
   constructor() {
     this.active = false;
     this.listenersMap = new WeakMap();
-    this.lensMap = new WeakMap(); // a map from editor to {lens, item, editorDims}
+    this.lensMap = new WeakMap(); // a map from editor to {lens, item, editorDims, minimapDims}
     this.timeoutId = null;
   }
 
@@ -180,14 +180,20 @@ class MinimapLens {
       if (!this.lensView) {
         return;
       }
+
+      // calc minimap dims
+      const minimapDims = this.calcMinimapDims(minimap);
+
+      // add editor and related values to the cache
       this.lensMap.set(editor, {
         lens: this.lensView,
         item,
         editorDims: {
           editorWidth,
           editorHeight
-        }
-      }); // add to cache
+        },
+        minimapDims
+      });
     } else {
       // show lens from cache
       // get the lensView from cache
@@ -268,15 +274,21 @@ class MinimapLens {
     return lens;
   }
 
-  setLensPosition(minimap, editor, lens, layerY) {
+  // minimap dimensions needed for setting location of lens
+  calcMinimapDims(minimap) {
     const minimapHeight = minimap.getHeight();
-    const minimapScrollTop = minimap.getScrollTop();
-    const minimapVisibleAreaTop =
-      minimap.getTextEditorScaledScrollTop() - minimapScrollTop;
     const minimapVisibleArea = atom.views
       .getView(minimap)
       .querySelector('.minimap-visible-area');
+    const minimapVisibleAreaClientHeight = minimapVisibleArea.clientHeight;
 
+    return {
+      minimapHeight,
+      minimapVisibleAreaClientHeight
+    };
+  }
+
+  setLensPosition(minimap, editor, lens, layerY) {
     if (
       minimapHeight < minimapScrollTop + layerY ||
       (minimapVisibleAreaTop <= layerY &&

--- a/lib/minimap-lens.js
+++ b/lib/minimap-lens.js
@@ -21,7 +21,7 @@ class MinimapLens {
   constructor() {
     this.active = false;
     this.listenersMap = new WeakMap();
-    this.lensMap = new WeakMap(); // a map from editor to {lens, item, editorWidth}
+    this.lensMap = new WeakMap(); // a map from editor to {lens, item, editorDims}
     this.timeoutId = null;
   }
 
@@ -169,7 +169,8 @@ class MinimapLens {
     const shouldCreateLens =
       !this.lensView || // no lens so far
       !editorHasLens || // editor does not have lens
-      (editorHasLens && this.lensMap.get(editor).editorWidth !== editorWidth); // editor width has changed
+      (editorHasLens &&
+        this.lensMap.get(editor).editorDims.editorWidth !== editorWidth); // editor width has changed
 
     if (shouldCreateLens) {
       // create lens from scratch
@@ -179,7 +180,14 @@ class MinimapLens {
       if (!this.lensView) {
         return;
       }
-      this.lensMap.set(editor, { lens: this.lensView, item, editorWidth }); // add to cache
+      this.lensMap.set(editor, {
+        lens: this.lensView,
+        item,
+        editorDims: {
+          editorWidth,
+          editorHeight
+        }
+      }); // add to cache
     } else {
       // show lens from cache
       // get the lensView from cache

--- a/lib/minimap-lens.js
+++ b/lib/minimap-lens.js
@@ -43,7 +43,9 @@ class MinimapLens {
   editorObserver() {
     const activeTextEditorObserver = atom.workspace.observeActiveTextEditor(
       editor => {
-        editor.onDidDestroy(() => this.destroyLens(editor));
+        if (editor) {
+          editor.onDidDestroy(() => this.destroyLens(editor));
+        }
       }
     );
     this.subscriptions.add(activeTextEditorObserver);

--- a/lib/minimap-lens.js
+++ b/lib/minimap-lens.js
@@ -32,6 +32,9 @@ class MinimapLens {
   activate() {
     this.subscriptions = new CompositeDisposable();
     this.subscriptions.add(
+      atom.config.observe('minimap-lens.lensHeight', h => {
+        this.lensHeight = h;
+      }),
       atom.config.observe('minimap-lens.lensDelay', v => {
         this.timeoutDelay = v;
       })
@@ -266,8 +269,7 @@ class MinimapLens {
     const minimapVisibleArea = atom.views
       .getView(minimap)
       .querySelector('.minimap-visible-area');
-    const lensHeight = getComputedStyle(lens, null).height;
-    const halfLensHeight = parseInt(lensHeight, 10) / 2;
+    const halfLensHeight = this.lensHeight / 2;
     const lensEditor = lens.querySelector('atom-text-editor');
 
     if (

--- a/lib/minimap-lens.js
+++ b/lib/minimap-lens.js
@@ -298,21 +298,18 @@ class MinimapLens {
     this.lensView.style.display = 'none'; // hide
   }
 
-  destroyLens() {
-    // clear previous lens memory
-    if (this.previousEditor && this.lensMap.has(this.previousEditor)) {
-      const { previousLens, previousItem } = this.lensMap.get(
-        this.previousEditor
-      );
-      if (previousItem) {
-        previousItem.destroy();
+  // clears the lens memory of the given editor if it had lens
+  destroyLens(editor) {
+    if (this.lensMap.has(editor)) {
+      const { lens, item } = this.lensMap.get(editor);
+      if (item) {
+        item.destroy();
       }
-      if (previousLens) {
-        previousLens.remove();
+      if (lens) {
+        lens.remove();
       }
-      this.lensMap.delete(this.previousEditor);
+      this.lensMap.delete(editor);
     }
-    this.previousEditor = this.editor; // update previousEditor
   }
 }
 

--- a/lib/minimap-lens.js
+++ b/lib/minimap-lens.js
@@ -36,6 +36,17 @@ class MinimapLens {
         this.timeoutDelay = v;
       })
     );
+    this.editorObserver();
+  }
+
+  // removes the lens when editor is destroyed
+  editorObserver() {
+    const activeTextEditorObserver = atom.workspace.observeActiveTextEditor(
+      editor => {
+        editor.onDidDestroy(() => this.destroyLens(editor));
+      }
+    );
+    this.subscriptions.add(activeTextEditorObserver);
   }
 
   consumeMinimapServiceV1(minimap1) {
@@ -216,7 +227,6 @@ class MinimapLens {
     if (!itemView) {
       return null;
     }
-    this.destroyLens(); // clean last lens memory
     const lensHeight = atom.config.get('minimap-lens.lensHeight');
     const clipInner = document.createElement('div');
     clipInner.classList.add('clip-inner');
@@ -280,12 +290,12 @@ class MinimapLens {
     this.setLensPosition(minimap, editor, this.lensView, layerY);
   }
 
+  // hides the lense when mouse leaves the minimap
   hideLens() {
     if (!this.lensView) {
       return;
     }
     this.lensView.style.display = 'none'; // hide
-    this.lensMap.delete(this.previousEditor);
   }
 
   destroyLens() {

--- a/lib/minimap-lens.js
+++ b/lib/minimap-lens.js
@@ -154,29 +154,30 @@ class MinimapLens {
   }
 
   showLens(editor, layerY) {
-    if (!editor || this.lensMap.has(editor)) return;
-    const item = editor.copy();
-    const minimap = this.minimap.minimapForEditor(editor);
+    if (!editor) return;
 
+    const minimap = this.minimap.minimapForEditor(editor);
     const [editorWidth, editorHeight] = this.calcEditorDims(minimap, editor);
 
-    if (
-      !this.lensView ||
-      this.editor != editor ||
-      this.editorWidth != editorWidth
-    ) {
+    // check if should create lens
+    const editorHasLens = this.lensMap.has(editor);
+    const shouldCreateLens =
+      !this.lensView || // no lens so far
+      !editorHasLens || // editor does not have lens
+      (editorHasLens && this.lensMap.get(editor).editorWidth !== editorWidth); // editor width has changed
+
+    if (shouldCreateLens) {
+      // create lens from scratch
+      const item = editor.copy(); // do not modify the original editor
       const itemView = this.prepareCreateLens(item, editorHeight, editorWidth);
-      this.editor = editor; // update editor cache (to check if editor is new)
-      this.editorWidth = editorWidth; // update editorWidth cache (to check if width has changed)
       this.lensView = this.createLens(minimap, editor, itemView); // create lens
       if (!this.lensView) {
         return;
       }
+      this.lensMap.set(editor, { lens: this.lensView, item, editorWidth }); // add to cache
     } else {
       this.lensView.style.display = ''; // show
     }
-    this.lensMap.set(editor, { lens: this.lensView, item });
-
     this.setLensPosition(minimap, editor, this.lensView, layerY);
   }
 

--- a/lib/minimap-lens.js
+++ b/lib/minimap-lens.js
@@ -276,8 +276,6 @@ class MinimapLens {
     const minimapVisibleArea = atom.views
       .getView(minimap)
       .querySelector('.minimap-visible-area');
-    const halfLensHeight = this.lensHeight / 2;
-    const lensEditor = lens.querySelector('atom-text-editor');
 
     if (
       minimapHeight < minimapScrollTop + layerY ||
@@ -289,6 +287,7 @@ class MinimapLens {
       lens.classList.remove('is-hide');
     }
 
+    const halfLensHeight = this.lensHeight / 2;
     const lensTranslateY = layerY - halfLensHeight;
     // @NOTE: Calculate the "actual" editor height, which corresponds to what `minimapHeight` represents
     //        `editor.getHeight()` includes the height of the margin(blank) area in bottom.
@@ -298,6 +297,8 @@ class MinimapLens {
       halfLensHeight;
 
     lens.style.transform = `translateY(${lensTranslateY}px)`;
+
+    const lensEditor = lens.querySelector('atom-text-editor');
     lensEditor.style.transform = `translateY(${lensEditorTransformY}px)`;
   }
 

--- a/lib/minimap-lens.js
+++ b/lib/minimap-lens.js
@@ -201,7 +201,17 @@ class MinimapLens {
       this.lensView = lensMap.lens;
       // show lens
       this.lensView.style.display = '';
+
+      // check if editor height has changed compared to cache
+      const editorHeightHasChanged =
+        this.lensMap.get(editor).editorDims.editorHeight !== editorHeight;
+      // update minimapDims if editor height has changed
+      if (editorHeightHasChanged) {
+        const minimapDims = this.calcMinimapDims(minimap);
+        this.lensMap.get(editor).minimapDims = minimapDims;
+      }
     }
+
     this.setLensPosition(minimap, editor, this.lensView, layerY);
   }
 
@@ -289,10 +299,19 @@ class MinimapLens {
   }
 
   setLensPosition(minimap, editor, lens, layerY) {
+    // get minimapDims from cache
+    const { minimapHeight, minimapVisibleAreaClientHeight } = this.lensMap.get(
+      editor
+    ).minimapDims;
+
+    const minimapScrollTop = minimap.getScrollTop();
+    const minimapVisibleAreaTop =
+      minimap.getTextEditorScaledScrollTop() - minimapScrollTop;
+
     if (
       minimapHeight < minimapScrollTop + layerY ||
       (minimapVisibleAreaTop <= layerY &&
-        layerY <= minimapVisibleAreaTop + minimapVisibleArea.clientHeight)
+        layerY <= minimapVisibleAreaTop + minimapVisibleAreaClientHeight)
     ) {
       lens.classList.add('is-hide');
     } else {

--- a/lib/minimap-lens.js
+++ b/lib/minimap-lens.js
@@ -217,6 +217,7 @@ class MinimapLens {
 
   // editor dimensions calculations needed for createLens
   calcEditorDims(minimap, editor) {
+    // TODO perform these calculations inside minimap-plus instead
     const minimapElement = atom.views.getView(minimap);
     const editorView = atom.views.getView(editor);
     const editorHeight = parseInt(
@@ -286,6 +287,8 @@ class MinimapLens {
 
   // minimap dimensions needed for setting location of lens
   calcMinimapDims(minimap) {
+    // TODO perform these calculations inside minimap-plus instead
+    // calling minimapVisibleArea.clientHeight is very expensive
     const minimapHeight = minimap.getHeight();
     const minimapVisibleArea = atom.views
       .getView(minimap)

--- a/lib/minimap-lens.js
+++ b/lib/minimap-lens.js
@@ -21,7 +21,7 @@ class MinimapLens {
   constructor() {
     this.active = false;
     this.listenersMap = new WeakMap();
-    this.lensMap = new WeakMap();
+    this.lensMap = new WeakMap(); // a map from editor to {lens, item, editorWidth}
     this.timeoutId = null;
   }
 
@@ -176,7 +176,12 @@ class MinimapLens {
       }
       this.lensMap.set(editor, { lens: this.lensView, item, editorWidth }); // add to cache
     } else {
-      this.lensView.style.display = ''; // show
+      // show lens from cache
+      // get the lensView from cache
+      const lensMap = this.lensMap.get(editor);
+      this.lensView = lensMap.lens;
+      // show lens
+      this.lensView.style.display = '';
     }
     this.setLensPosition(minimap, editor, this.lensView, layerY);
   }


### PR DESCRIPTION
- This optimizes `setLensPosition` so it does not calculate the known `lensHeight` using the expensive `getComputedStyle` function. This function takes ~150ms each time a lens is shown. Now the `lensHeight` simply gotten from the configs.

- Caches the minimap dimensions and editor height. It uses this cache instead of recalculating the `minimapDims` every time inside `setLensPosition`. This function is very expensive in long files (~800-3000ms!). Now it is only called once initially or if the editor's height changes.

# This should be merged after #23

@iyonaga 