### PR TITLE
make event listeners passive

### DIFF
--- a/lib/minimap-lens.js
+++ b/lib/minimap-lens.js
@@ -87,11 +87,21 @@ class MinimapLens {
         onMouseReleased
       };
 
-      minimapElement.addEventListener('mouseenter', onMouseEnter);
-      minimapElement.addEventListener('mousemove', onMouseMove);
-      minimapElement.addEventListener('mouseleave', onMouseLeave);
-      minimapElement.addEventListener('mousedown', onMousePressed);
-      minimapElement.addEventListener('mouseup', onMouseReleased);
+      minimapElement.addEventListener('mouseenter', onMouseEnter, {
+        passive: true
+      });
+      minimapElement.addEventListener('mousemove', onMouseMove, {
+        passive: true
+      });
+      minimapElement.addEventListener('mouseleave', onMouseLeave, {
+        passive: true
+      });
+      minimapElement.addEventListener('mousedown', onMousePressed, {
+        passive: true
+      });
+      minimapElement.addEventListener('mouseup', onMouseReleased, {
+        passive: true
+      });
 
       this.listenersMap.set(minimapElement, listeners);
     });


### PR DESCRIPTION
This improves scrolling performance by making the event listeners passive.

Based on 
https://developers.google.com/web/updates/2016/06/passive-event-listeners
and
https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#Improving_scrolling_performance_with_passive_listeners

This prevents minimap-lens to get in the way of scrolling.