### PR TITLE
fix: fast calcMinimapDims

### DIFF
--- a/lib/minimap-lens.js
+++ b/lib/minimap-lens.js
@@ -287,23 +287,19 @@ class MinimapLens {
 
   // minimap dimensions needed for setting location of lens
   calcMinimapDims(minimap) {
-    // TODO perform these calculations inside minimap-plus instead
-    // calling minimapVisibleArea.clientHeight is very expensive
     const minimapHeight = minimap.getHeight();
-    const minimapVisibleArea = atom.views
-      .getView(minimap)
-      .querySelector('.minimap-visible-area');
-    const minimapVisibleAreaClientHeight = minimapVisibleArea.clientHeight;
-
+    const minimapVisibleAreaHeight = Math.round(
+      minimap.getTextEditorScaledHeight()
+    );
     return {
       minimapHeight,
-      minimapVisibleAreaClientHeight
+      minimapVisibleAreaHeight
     };
   }
 
   setLensPosition(minimap, editor, lens, layerY) {
     // get minimapDims from cache
-    const { minimapHeight, minimapVisibleAreaClientHeight } = this.lensMap.get(
+    const { minimapHeight, minimapVisibleAreaHeight } = this.lensMap.get(
       editor
     ).minimapDims;
 
@@ -314,7 +310,7 @@ class MinimapLens {
     if (
       minimapHeight < minimapScrollTop + layerY ||
       (minimapVisibleAreaTop <= layerY &&
-        layerY <= minimapVisibleAreaTop + minimapVisibleAreaClientHeight)
+        layerY <= minimapVisibleAreaTop + minimapVisibleAreaHeight)
     ) {
       lens.classList.add('is-hide');
     } else {


### PR DESCRIPTION
This improves the time it takes to calculate minimap dims. Previously, it was a huge time and that's why I cached inside #24. This function is very expensive in long files (~800-3000ms!). Now, this is less than 1ms! 🚀 

