### PR TITLE
Set the default delay to 300ms

### DIFF
--- a/lib/minimap-lens.js
+++ b/lib/minimap-lens.js
@@ -11,9 +11,10 @@ class MinimapLens {
       minimum: 100
     },
     lensDelay: {
-      description: 'Delay before showing the lens (in ms)',
+      description:
+        'Delay before showing the lens (in ms). Setting this number lower than the default causes performance issues.',
       type: 'integer',
-      default: 0,
+      default: 300,
       minimum: 0
     }
   };


### PR DESCRIPTION
This helps in two situations:
- In large files, suddenly grabbing the minimap slider and trying to scroll does not have a lag anymore. So the lens does not get in the way of scrolling.

- When constantly want to edit things on the sidebars, the lens does not appear every time.

