### PR TITLE
disable lens in large files

### DIFF
--- a/lib/minimap-lens.js
+++ b/lib/minimap-lens.js
@@ -16,6 +16,13 @@ class MinimapLens {
       type: 'integer',
       default: 300,
       minimum: 0
+    },
+    largeFileLinesNum: {
+      description:
+        'When the number of lines of an editor is larger than this number, the minimap lens is disabled to prevent slowing down of the editor.',
+      type: 'integer',
+      default: 1500,
+      minimum: 1
     }
   };
 

--- a/lib/minimap-lens.js
+++ b/lib/minimap-lens.js
@@ -30,6 +30,7 @@ class MinimapLens {
     this.active = false;
     this.listenersMap = new WeakMap();
     this.lensMap = new WeakMap(); // a map from editor to {lens, item, editorDims, minimapDims}
+    this.thrownLargeFileWarning = new WeakMap(); // a map from editor to boolean
     this.timeoutId = null;
   }
 
@@ -125,6 +126,9 @@ class MinimapLens {
   }
 
   onMouseEnter(editor, e) {
+    if (this.isInLargeFileMode(editor)) {
+      return;
+    }
     if (this.timeoutDelay > 0) {
       this.timeoutId = setTimeout(() => {
         this.timeoutId = null;
@@ -136,10 +140,16 @@ class MinimapLens {
   }
 
   onMouseMove(editor, e) {
+    if (this.isInLargeFileMode(editor)) {
+      return;
+    }
     this.updateLensPosition(editor, e.layerY);
   }
 
-  onMouseLeave() {
+  onMouseLeave(editor, e) {
+    if (this.isInLargeFileMode(editor)) {
+      return;
+    }
     if (this.timeoutId !== null) {
       clearTimeout(this.timeoutId);
       this.timeoutId = null;
@@ -149,6 +159,9 @@ class MinimapLens {
   }
 
   onMousePressed(editor, e) {
+    if (this.isInLargeFileMode(editor)) {
+      return;
+    }
     // if mouse is pressed hide the lens
     if (typeof e === 'object' && e.button == 0) {
       this.hideLens();
@@ -156,9 +169,30 @@ class MinimapLens {
   }
 
   onMouseReleased(editor, e) {
+    if (this.isInLargeFileMode(editor)) {
+      return;
+    }
     // when mouse is released show the lens
     if (typeof e === 'object' && e.button == 0) {
       this.showLens(editor, e.layerY);
+    }
+  }
+
+  isInLargeFileMode(editor) {
+    if (
+      editor.largeFileMode ||
+      editor.getLineCount() >= atom.config.get('minimap-lens.largeFileLinesNum')
+    ) {
+      if (!this.thrownLargeFileWarning.get(editor)) {
+        this.thrownLargeFileWarning.set(editor, true);
+        atom.notifications.addWarning(
+          'Minimap Lens is disabled in large files to prevent slowing down the editor.'
+        );
+      }
+      return true;
+    } else {
+      this.thrownLargeFileWarning.set(editor, false);
+      return false;
     }
   }
 
@@ -393,6 +427,7 @@ class MinimapLens {
         lens.remove();
       }
       this.lensMap.delete(editor);
+      this.thrownLargeFileWarning.delete(editor);
     }
   }
 }


### PR DESCRIPTION
This pull request adds a large file mode to disable the lens.

Despite all the optimizations I made in #31 #30 #29 #28 #24 #23 #21 #20 #19 #18 and #17, in very large files minimap lens blocks the main thread and prevents Atom to function properly. This is the limitation of [`appendChild`](https://github.com/iyonaga/minimap-lens/blob/5cb03d093d06bea3865536a307270bb8090f3750/lib/minimap-lens.js#L301) in JavaScript. This single function call blocks the main thread and there is no way to use multi-threading here (as it is doing DOM manipulation).

Until we use something faster than `appendChild` (like using back-end rendering to constantly render the lens in the background and send it as a string to the UI or using canvas to sample the editor similar to Minimap itself or), we should disable the lens in large files. I have made [a question in StackOverflow](https://stackoverflow.com/questions/63220794/fast-alternative-to-appendchild) to get ideas about this


Fixes #27 